### PR TITLE
Add required $endpoint parameter to dynamodb

### DIFF
--- a/src/Aws/DynamoDb/ClientFactory.php
+++ b/src/Aws/DynamoDb/ClientFactory.php
@@ -8,12 +8,18 @@ use Aws\DynamoDb\DynamoDbClient;
 
 final class ClientFactory
 {
-    public function build(Credentials $credentials, string $region): DynamoDbClient
+    public function build(Credentials $credentials, string $region, string $endpoint): DynamoDbClient
     {
-        return new DynamoDbClient([
+        $config = [
             'credentials' => $credentials,
             'region' => $region,
             'version' => 'latest',
-        ]);
+        ];
+
+        if ($endpoint) {
+            $config['endpoint'] = $endpoint;
+        }
+
+        return new DynamoDbClient($config);
     }
 }


### PR DESCRIPTION
Required $endpoint parameter to use local environment like `http://dynamodb:8000` it is already in docs