### PR TITLE
[AE-272]TimeStream docs & composer require php>=7.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 * [S3](docs/s3.md)
 * [SQS](docs/sqs.md)
 * [SNS](docs/sns.md)
+* [TimeStream](docs/time-stream.md)
 
 ## Thank you
 

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "library",
     "license": "MIT",
     "require": {
-        "php": "^7.4",
+        "php": ">=7.4",
         "ext-json": "*",
         "aws/aws-sdk-php": "^3.172"
     },

--- a/docs/time-stream.md
+++ b/docs/time-stream.md
@@ -29,3 +29,25 @@ services:
             - '@aws.credentials'
             - '%aws.region.west%'
 ```
+
+## Usage example
+
+```php
+$stream = new MemoryTimeSeries(); // use TimeStreamClient from DI in prod
+$stream->write(
+    new AttributeName('database_name'),
+    new AttributeName('table_name'),
+    new Record(
+        new SecondsDataPoint(
+            new BigIntMeasure(
+                new AttributeName('measure_name'),
+                $measureValue = 100
+            )
+        ),
+        new Dimension(
+            new AttributeName('dimension_name'),
+            'dimension_value'
+        )
+    )
+);
+```

--- a/docs/time-stream.md
+++ b/docs/time-stream.md
@@ -1,0 +1,31 @@
+# AWS S3
+
+## ENV
+
+Required `ENV` variables
+
+```dotenv
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+```
+
+## Default configuration
+
+```yaml
+parameters:
+    aws.region.west: 'eu-west-1'
+
+services:
+    aws.credentials:
+        class: 'Aws\Credentials\Credentials'
+        arguments: ['%env(AWS_ACCESS_KEY_ID)%', '%env(AWS_SECRET_ACCESS_KEY)%']
+
+    Landingi\AwsBundle\Aws\TimeStream\ClientFactory: ~
+
+    Landingi\AwsBundle\TimeStream\TimeSeries:
+        class: Landingi\AwsBundle\Aws\TimeStream\TimeStreamClient
+        factory: ['@Landingi\AwsBundle\Aws\TimeStream\ClientFactory', 'build']
+        arguments:
+            - '@aws.credentials'
+            - '%aws.region.west%'
+```


### PR DESCRIPTION
Require php >= 7.4 to so php8 projects can install it.