### PR TITLE
[APP-1503]Add square brackets for delete doc in CloudSearch

### DIFF
--- a/src/Aws/CloudSearch/CloudSearch.php
+++ b/src/Aws/CloudSearch/CloudSearch.php
@@ -44,8 +44,10 @@ final class CloudSearch implements SearchClient
     {
         $this->uploadDocuments(
             [
-                'type' => 'delete',
-                'id' => $documentIdentifier->toString(),
+                [
+                    'type' => 'delete',
+                    'id' => $documentIdentifier->toString(),
+                ]
             ]
         );
     }


### PR DESCRIPTION
When we try to delete document from AWS we get error, now response to AWS will be like this `[{"type":"delete","id":"6e764fa67188d6d0572f"}]`