### PR TITLE
[OP-1123] Bumped deprecated GHAs in ci.yml file

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,8 @@
-# on:
-#     pull_request:
-#     push:
-#         branches:
-#             - main
 on:
     pull_request:
     push:
         branches:
-            - OP-1123-GHA-bump-deprecated-gha
+            - main
 jobs:
     static-analyze:
         runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,13 +1,18 @@
+# on:
+#     pull_request:
+#     push:
+#         branches:
+#             - main
 on:
     pull_request:
     push:
         branches:
-            - main
+            - OP-1123-GHA-bump-deprecated-gha
 jobs:
     static-analyze:
         runs-on: ubuntu-20.04
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '7.4'
@@ -15,7 +20,7 @@ jobs:
                 run: composer validate --strict
             -   name: Cache Composer packages
                 id: composer-cache
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: vendor
                     key: composer-${{ hashFiles('composer.lock') }}
@@ -26,7 +31,7 @@ jobs:
     tests:
         runs-on: ubuntu-20.04
         steps:
-            -   uses: actions/checkout@v2
+            -   uses: actions/checkout@v4
             -   uses: shivammathur/setup-php@v2
                 with:
                     php-version: '7.4'
@@ -34,7 +39,7 @@ jobs:
                 run: composer validate --strict
             -   name: Cache Composer packages
                 id: composer-cache
-                uses: actions/cache@v3
+                uses: actions/cache@v4
                 with:
                     path: vendor
                     key: composer-${{ hashFiles('composer.lock') }}


### PR DESCRIPTION
[OP-1123] Bumped deprecated GHAs in ci.yml file

**Ci.yml**
  1. actions/checkout@v2 -> v4
  2. actions/cache@v3 -> v4

[OP-1123]: https://landingi.atlassian.net/browse/OP-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ