### PR TITLE
Fix CloudSearch Lucene query builder when a percentage sign appears in a search query

### DIFF
--- a/src/Aws/CloudSearch/RequestParameter/Query/Builder/LuceneQueryParametersBuilder.php
+++ b/src/Aws/CloudSearch/RequestParameter/Query/Builder/LuceneQueryParametersBuilder.php
@@ -146,7 +146,7 @@ final class LuceneQueryParametersBuilder
             $matchPatternWithField = sprintf(
                 '%s (%s)',
                 self::SEARCH_FIELD_PATTERN,
-                $wildcardQuery
+                str_replace('%', '%%', $wildcardQuery)
             );
             $queryTokenParts = array_map(
                 static fn (string $searchField) => sprintf($matchPatternWithField, $searchField, $queryToken),

--- a/tests/Aws/CloudSearch/RequestParameter/Query/Builder/LuceneQueryParametersBuilderTest.php
+++ b/tests/Aws/CloudSearch/RequestParameter/Query/Builder/LuceneQueryParametersBuilderTest.php
@@ -111,5 +111,9 @@ final class LuceneQueryParametersBuilderTest extends TestCase
             '!~@#^$ \\',
             '((field1: "!~@#^$" OR field1: (*@#* AND *$*)) AND field1: "\\\")',
         ];
+        yield [
+            'GD-XMAS-30%',
+            '(field1: "GD-XMAS-30%" OR field1: (*GD* AND *XMAS* AND *30%*))',
+        ];
     }
 }


### PR DESCRIPTION
Resolves error when additional parameter was needed due to unescaped '%' sign in sprintf.