### PR TITLE
[LAND-243]Add SQS Delay 1s constructor 

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -5,7 +5,7 @@ on:
             - main
 jobs:
     static-analyze:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             -   uses: actions/checkout@v4
             -   uses: shivammathur/setup-php@v2
@@ -24,7 +24,7 @@ jobs:
             -   run: vendor/bin/phpstan analyse -c phpstan.neon
 #            -   run: vendor/bin/ecs check --config vendor/landingi/php-coding-standards/ecs.php
     tests:
-        runs-on: ubuntu-20.04
+        runs-on: ubuntu-24.04
         steps:
             -   uses: actions/checkout@v4
             -   uses: shivammathur/setup-php@v2

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Latest Stable Version](https://poser.pugx.org/landingi/aws-bundle/v)](https://packagist.org/packages/landingi/awws-bundle)
 [![Total Downloads](https://poser.pugx.org/landingi/aws-bundle/downloads)](https://packagist.org/packages/landingi/aws-bundle)
 [![License](https://poser.pugx.org/landingi/aws-bundle/license)](https://packagist.org/packages/landingi/aws-bundle)
-[![codecov](https://codecov.io/gh/landingi/aws-bundle/branch/master/graph/badge.svg?token=DAN4LKMI3S)](https://codecov.io/gh/landingi/aws-bundle)
 
 # Landingi AWS Bundle (PoC) 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,11 +5,11 @@ services:
         volumes:
             - ./:/app:delegated
         networks:
-            - ferror
+            - landingi-aws-bundle
 
 networks:
-    ferror:
-        name: ferror
+    landingi-aws-bundle:
+        name: landingi-aws-bundle
         driver: bridge
         ipam:
             driver: default

--- a/src/Aws/Sqs/Delay.php
+++ b/src/Aws/Sqs/Delay.php
@@ -18,6 +18,11 @@ final class Delay implements MessageMetadata
         return new self(0);
     }
 
+    public static function oneSecond(): self
+    {
+        return new self(1);
+    }
+
     /**
      * @throws \Landingi\AwsBundle\Queue\QueueException
      */


### PR DESCRIPTION
This will make it easier to use a non-zero delay without having to use the regular constructor with arbitrary numbers.
Also adds minor cleanup/upgrade changes:
- update Github actions runner to Ubuntu 24.04
- rename the docker network to a more appropriate name
- remove Codecov from readme, as we don't use it anymore